### PR TITLE
Add full team as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# This CODEOWNERS file defines individuals or teams that are responsible
+# for code in this repository.
+# See https://help.github.com/articles/about-codeowners/ for details.
+
+* @mozilla/uniffi-devs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # for code in this repository.
 # See https://help.github.com/articles/about-codeowners/ for details.
 
-* @mozilla/uniffi-devs
+* @badboy

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,48 @@
+queue_rules:
+  - name: default
+    conditions:
+      # Conditions to get out of the queue (= merged)
+      - "check-success=ci/circleci: Check Rust formatting"
+      - "check-success=ci/circleci: Lint Rust Docs"
+      - "check-success=ci/circleci: Lint Rust with clippy"
+      - "check-success=ci/circleci: Rust and Foreign Language tests"
+      - "check-success=ci/circleci: Rust and Foreign Language tests - min supported rust"
+      - "#check-pending=0"
+      - "#check-stale=0"
+      - "#check-failure=0"
+pull_request_rules:
+  - name: Resolve conflict
+    conditions:
+      - conflict
+    actions:
+        comment:
+          message: This pull request has conflicts when rebasing. Could you fix it @{{author}}? 🙏
+  - name: automatic merge for main
+    conditions:
+      - "#approved-reviews-by>=1"
+      - base=main
+      - -draft
+      - label=checkin-needed
+      # What we want to say here is "all checks passed", but that's not a concept
+      # that makes sense in GitHub:
+      #
+      #    https://docs.mergify.io/conditions/#validating-all-status-checks
+      - "check-success=ci/circleci: Check Rust formatting"
+      - "check-success=ci/circleci: Lint Rust Docs"
+      - "check-success=ci/circleci: Lint Rust with clippy"
+      - "check-success=ci/circleci: Rust and Foreign Language tests"
+      - "check-success=ci/circleci: Rust and Foreign Language tests - min supported rust"
+      - "#check-pending=0"
+      - "#check-stale=0"
+      - "#check-failure=0"
+    actions:
+      # This merges by rebasing without strict merge, which means that mergify will *attempt*
+      # to rebase a matching PR directly on to the `main` branch, even if the PR is out of date.
+      # However, our GitHub branch protection rules require that PRs must be up-to-date before merging,
+      # and mergify respects these rules, so the expected behaviour here is that mergify will only
+      # merge when it can cleanly put the exact commits of the PR directly on top of `main`
+      # (and thus avoid having to re-write any commits or create merge commits of its own).
+      queue:
+        method: rebase
+        name: default
+        rebase_fallback: none


### PR DESCRIPTION
Making use of GitHub's ability to auto-assign people from a team in a
round-robin fashion:
https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team#routing-algorithms